### PR TITLE
Update to node16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,5 +37,5 @@ inputs:
       Defaults to `0`. `-1` means infinite.
 
 runs:
-  using: "node12"
+  using: node16
   main: "dist/index.js"


### PR DESCRIPTION
Closes https://github.com/jupyterhub/action-k8s-await-workloads/issues/53

GitHub say this should be treated as a breaking change: https://github.blog/changelog/2022-05-20-actions-can-now-run-in-a-node-js-16-runtime/